### PR TITLE
[ci skip] adding user @tomasvanpottelbergh

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @cdesouza21
+* @tomasvanpottelbergh

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,4 +51,5 @@ about:
 
 extra:
   recipe-maintainers:
+    - tomasvanpottelbergh
     - cdesouza21


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @tomasvanpottelbergh as instructed in #22.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Fixes #22